### PR TITLE
docs: override title with partial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 coverage
 docs/
 __pycache__
+.coverage

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,3 +1,5 @@
+title: |-
+    # [Google Cloud Firestore Session](https://github.com/googleapis/nodejs-firestore-session)
 introduction: |-
     > An [express](http://expressjs.com/) session store backed by [Google Cloud Firestore][product-docs].
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [Google Cloud Firestore Session: Node.js Client](https://github.com/googleapis/nodejs-firestore-session)
+# [Google Cloud Firestore Session](https://github.com/googleapis/nodejs-firestore-session)
+
 
 [![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/connect-firestore.svg)](https://www.npmjs.org/package/@google-cloud/connect-firestore)

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,7 +2,8 @@
 [//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [Google Cloud Firestore Session: Node.js Samples](https://github.com/googleapis/nodejs-firestore-session)
+# [Google Cloud Firestore Session](https://github.com/googleapis/nodejs-firestore-session) Samples
+
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 


### PR DESCRIPTION
As @JustinBeckwith pointed out yesterday, our default title is a bit weird for these utility libraries, this demonstrates using a `title` partial to override it.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
