### PR TITLE
build: update system-test and sample-test config

### DIFF
--- a/.kokoro/continuous/node10/samples-test.cfg
+++ b/.kokoro/continuous/node10/samples-test.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-firestore-session/.kokoro/samples-test.sh"
 }
+
+env_vars: {
+    key: "SECRET_MANAGER_KEYS"
+    value: "nodejs-firestore-ci-samples-71b5f8aee66e"
+}

--- a/.kokoro/continuous/node10/system-test.cfg
+++ b/.kokoro/continuous/node10/system-test.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-firestore-session/.kokoro/system-test.sh"
 }
+
+env_vars: {
+    key: "SECRET_MANAGER_KEYS"
+    value: "nodejs-firestore-ci-samples-71b5f8aee66e"
+}

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function now { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n' ;}
+function msg { println "$*" >&2 ;}
+function println { printf '%s\n' "$(now) $*" ;}
+
+
+# Populates requested secrets set in SECRET_MANAGER_KEYS from service account:
+# kokoro-trampoline@cloud-devrel-kokoro-resources.iam.gserviceaccount.com
+SECRET_LOCATION="${KOKORO_GFILE_DIR}/secret_manager"
+msg "Creating folder on disk for secrets: ${SECRET_LOCATION}"
+mkdir -p ${SECRET_LOCATION}
+for key in $(echo ${SECRET_MANAGER_KEYS} | sed "s/,/ /g")
+do
+  msg "Retrieving secret ${key}"
+  docker run --entrypoint=gcloud \
+    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
+    gcr.io/google.com/cloudsdktool/cloud-sdk \
+    secrets versions access latest \
+    --credential-file-override=${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json \
+    --project cloud-devrel-kokoro-resources \
+    --secret $key > \
+    "$SECRET_LOCATION/$key"
+  if [[ $? == 0 ]]; then
+    msg "Secret written to ${SECRET_LOCATION}/${key}"
+  else
+    msg "Error retrieving secret ${key}"
+  fi
+done

--- a/.kokoro/presubmit/node10/samples-test.cfg
+++ b/.kokoro/presubmit/node10/samples-test.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-firestore-session/.kokoro/samples-test.sh"
 }
+
+env_vars: {
+    key: "SECRET_MANAGER_KEYS"
+    value: "nodejs-firestore-ci-samples-71b5f8aee66e"
+}

--- a/.kokoro/presubmit/node10/system-test.cfg
+++ b/.kokoro/presubmit/node10/system-test.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-firestore-session/.kokoro/system-test.sh"
 }
+
+env_vars: {
+    key: "SECRET_MANAGER_KEYS"
+    value: "nodejs-firestore-ci-samples-71b5f8aee66e"
+}

--- a/.kokoro/setup-vars.sh
+++ b/.kokoro/setup-vars.sh
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export GCLOUD_PROJECT=node-gcloud-ci
-export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_GFILE_DIR/firestore-key.json
+export GCLOUD_PROJECT=nodejs-firestore-ci
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secret_manager/nodejs-firestore-ci-samples-71b5f8aee66e

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -24,4 +24,5 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+$(dirname $0)/populate-secrets.sh # Secret Manager secrets.
 python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"


### PR DESCRIPTION
Add new script .kokoro/populate-secrets.sh which supports the new
SECRET_MANAGER_KEYS configured for each build.

Update kokoro trampoline to call populate-secrets.sh

Update system-test & samples-test config to use a new project
`nodejs-firestore-ci` and a new secret for its credentials.


Fixes #133 