### PR TITLE
fix(types): patch in express type removed SessionData

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@google-cloud/firestore": "^4.0.0",
     "@microsoft/api-documenter": "^7.8.10",
     "@microsoft/api-extractor": "^7.8.10",
-    "@types/express-session": "^1.17.3",
     "@types/mocha": "^8.0.0",
     "c8": "^7.0.0",
     "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@google-cloud/firestore": "^4.0.0",
     "@microsoft/api-documenter": "^7.8.10",
     "@microsoft/api-extractor": "^7.8.10",
+    "@types/express-session": "^1.17.3",
     "@types/mocha": "^8.0.0",
     "c8": "^7.0.0",
     "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",
     "@google-cloud/firestore": "^4.0.0",
-    "@types/express-session": "^1.15.12",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
+    "@types/express-session": "^1.17.3",
     "@types/mocha": "^8.0.0",
+    "c8": "^7.0.0",
     "express": "^4.16.4",
     "express-session": "^1.15.6",
     "gts": "^2.0.0",
     "linkinator": "^2.0.0",
     "mocha": "^8.0.0",
-    "c8": "^7.0.0",
-    "typescript": "^3.8.3",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "typescript": "^3.8.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,7 @@ export class FirestoreStore extends Store {
   db: Firestore;
   kind: string;
   constructor(options: StoreOptions) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    super((options || {}) as any);
+    super();
     this.db = options.dataset;
     if (!this.db) {
       throw new Error('No dataset provided to Firestore Session.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Firestore} from '@google-cloud/firestore';
-import {Store} from 'express-session';
+import {Store, SessionData} from 'express-session';
 
 export interface StoreOptions {
   dataset: Firestore;
@@ -24,7 +24,8 @@ export class FirestoreStore extends Store {
   db: Firestore;
   kind: string;
   constructor(options: StoreOptions) {
-    super(options || {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    super((options || {}) as any);
     this.db = options.dataset;
     if (!this.db) {
       throw new Error('No dataset provided to Firestore Session.');
@@ -34,7 +35,7 @@ export class FirestoreStore extends Store {
 
   get = (
     sid: string,
-    callback: (err?: Error | null, session?: Express.SessionData) => void
+    callback: (err?: Error | null, session?: SessionData) => void
   ) => {
     this.db
       .collection(this.kind)
@@ -56,7 +57,7 @@ export class FirestoreStore extends Store {
 
   set = (
     sid: string,
-    session: Express.SessionData,
+    session: SessionData,
     callback?: (err?: Error) => void
   ) => {
     callback = callback || (() => {});

--- a/system-test/session.ts
+++ b/system-test/session.ts
@@ -16,6 +16,7 @@ import {Firestore} from '@google-cloud/firestore';
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {FirestoreStore} from '../src';
+import {SessionData} from 'express-session';
 
 const store = new FirestoreStore({
   dataset: new Firestore(),
@@ -31,7 +32,7 @@ describe('system tests', () => {
   });
 
   it('Should create and retrieve a session', done => {
-    const sessionData = ({foo: 'bar'} as {}) as Express.SessionData;
+    const sessionData = ({foo: 'bar'} as {}) as SessionData;
     store.set('123', sessionData, err => {
       assert.ifError(err);
       store.get('123', (err, session) => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -17,6 +17,7 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 
 import {FirestoreStore} from '../src/index';
+import {SessionData} from 'express-session';
 
 describe('firestore session', () => {
   it('should throw without dataset', done => {
@@ -96,7 +97,7 @@ describe('firestore session', () => {
     });
 
     const expectedSid = 'sid';
-    store.set(expectedSid, {} as Express.SessionData, assert.ifError);
+    store.set(expectedSid, {} as SessionData, assert.ifError);
   });
 
   it('should destroy a document', done => {


### PR DESCRIPTION
Express no longer exports SessionData.

Fixes #148 